### PR TITLE
Add Dockerfile and Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libssl-dev \
+        postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+COPY Gemfile Gemfile.lock ./
+COPY engines engines
+RUN bundle install
+COPY . .
+
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -55,11 +55,11 @@ gem 'foreman'
 gem 'whenever', :require => false
 
 # DB backup/restore tool https://github.com/ludicast/yaml_db
-gem 'yaml_db', github: 'jetthoughts/yaml_db', ref: 'fb4b6bd7e12de3cffa93e0a298a1e5253d7e92ba'
+gem 'yaml_db', :git => 'https://github.com/jetthoughts/yaml_db', ref: 'fb4b6bd7e12de3cffa93e0a298a1e5253d7e92ba'
 
 gem 'spree', :git => 'https://github.com/spree/spree.git', :branch => '2-2-stable'
 gem 'spree_gateway', :git => 'https://github.com/spree/spree_gateway.git', :branch => '2-2-stable'
-gem 'spree_active_shipping', :git => "git://github.com/spree/spree_active_shipping", :branch => '2-2-stable'
+gem 'spree_active_shipping', :git => "https://github.com/spree/spree_active_shipping", :branch => '2-2-stable'
 gem 'spree_auth_devise', :git => 'https://github.com/spree/spree_auth_devise.git', :branch => '2-2-stable'
 gem 'spree_bootstrap_frontend', :git => 'https://github.com/brewbit/spree_bootstrap_frontend.git', :branch => '2-2-stable'
 gem 'spree_brewbit', :path => 'engines/spree_brewbit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,4 @@
 GIT
-  remote: git://github.com/jetthoughts/yaml_db.git
-  revision: fb4b6bd7e12de3cffa93e0a298a1e5253d7e92ba
-  ref: fb4b6bd7e12de3cffa93e0a298a1e5253d7e92ba
-  specs:
-    yaml_db (0.2.3)
-
-GIT
-  remote: git://github.com/spree/spree_active_shipping
-  revision: f99ded1e36ebfaa8ad38a9e9883ab4ecebfe482a
-  branch: 2-2-stable
-  specs:
-    spree_active_shipping (2.2.0)
-      active_shipping (~> 0.12.0)
-      spree_core (~> 2.2.0)
-
-GIT
   remote: https://github.com/brewbit/bootstrap-sass.git
   revision: 4f65a8222866d0069f25efd447878cba7f09eb5b
   branch: master
@@ -24,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/brewbit/brewbit-dashboard.git
-  revision: c8ce23f8450a8c5d65323a19efea5bdf5bcc3a62
+  revision: 1d920be2d2794a4ec9f0bc70932943366b8ed125
   branch: master
   specs:
     brewbit_dashboard (2.2.0)
@@ -47,6 +31,13 @@ GIT
       bootstrap-sass (~> 3.1.0)
       kaminari-bootstrap (~> 3.0.1)
       spree_core (~> 2.2.0)
+
+GIT
+  remote: https://github.com/jetthoughts/yaml_db
+  revision: fb4b6bd7e12de3cffa93e0a298a1e5253d7e92ba
+  ref: fb4b6bd7e12de3cffa93e0a298a1e5253d7e92ba
+  specs:
+    yaml_db (0.2.3)
 
 GIT
   remote: https://github.com/spree/spree.git
@@ -105,6 +96,15 @@ GIT
       spree_core (= 2.2.10.beta)
 
 GIT
+  remote: https://github.com/spree/spree_active_shipping
+  revision: fed2733027c2c66039cd1b4866c0ca910a849207
+  branch: 2-2-stable
+  specs:
+    spree_active_shipping (2.2.0)
+      active_shipping (~> 0.12.0)
+      spree_core (~> 2.2.0)
+
+GIT
   remote: https://github.com/spree/spree_auth_devise.git
   revision: 01901766a2562026e2f3eb523a3f0f9bea8ae31e
   branch: 2-2-stable
@@ -155,7 +155,7 @@ GEM
       erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    active_shipping (0.12.5)
+    active_shipping (0.12.6)
       active_utils (~> 2.2.0)
       activesupport (>= 2.3.5)
       builder
@@ -282,7 +282,7 @@ GEM
       money (~> 6.5.0)
     money (6.5.0)
       i18n (>= 0.6.4, <= 0.7.0)
-    multi_json (1.10.1)
+    multi_json (1.13.1)
     multi_xml (0.5.5)
     nested_form (0.3.2)
     nokogiri (1.6.5)
@@ -304,7 +304,7 @@ GEM
       rack (>= 1.1, < 2.0)
     rabl (0.9.3)
       activesupport (>= 2.3.14)
-    rack (1.5.2)
+    rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.0.12)
@@ -320,7 +320,7 @@ GEM
       activesupport (= 4.0.12)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.4.2)
+    rake (12.3.2)
     ransack (1.1.0)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
@@ -349,13 +349,13 @@ GEM
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
-    thor (0.19.1)
-    thread_safe (0.3.4)
+    thor (0.19.4)
+    thread_safe (0.3.6)
     tilt (1.4.1)
     truncate_html (0.9.2)
     turbolinks (2.5.3)
       coffee-rails
-    tzinfo (0.3.42)
+    tzinfo (0.3.55)
     uglifier (2.7.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -369,7 +369,7 @@ GEM
       rack (>= 1.0)
     whenever (0.9.4)
       chronic (>= 0.6.3)
-    zeroclipboard-rails (0.1.0)
+    zeroclipboard-rails (0.1.2)
       railties (>= 3.1)
 
 PLATFORMS
@@ -405,3 +405,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   whenever
   yaml_db!
+
+BUNDLED WITH
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -40,3 +40,39 @@ bundle exec unicorn_rails -c config/unicorn.rb -D
 
 Server is now accessible on `http://brewbit.com`
 
+
+## Docker
+
+It is possible to run a fully-local copy of the BrewBit backend services (see below for an overview) using Docker Compose.
+
+1. Modify the database name in `config/database.yml` to read `host: db` (instead of localhost).
+
+2. Specify a permanent storage location for the PostgreSQL data by editing `docker-compose.yml`.
+
+3. Git clone [brewbit/brewbit-device-server](https://github.com/brewbit/brewbit-device-server). Both `brewbit.com` and `brewbit-device-server` should be located in the same directory. (The path to `brewbit-device-server` be changed in `docker-compose.yml`.)
+
+4. Configure your router's DNS to resolve `dg.brewbit.com` to the address of your local server. This is a workaround, since the gateway server location is compiled into the [Model-T firmware](https://github.com/brewbit/model-t).
+
+5. Launch the services using Docker Compose and instantiate the database:
+
+```
+docker-compose build
+docker-compose run web rake db:create
+docker-compose run web rake db:migrate
+docker-compose up
+```
+
+The website will appear at [http://localhost:3000](http://localhost:3000), and you will be able to create an account and log in.
+
+
+# Architecture Overview
+
+There are three main backend services for BrewBit:
+
+* [brewbit/brewbit-device-server](https://github.com/brewbit/brewbit-device-server) acts as an intermediary between the Model-T device and the web dashboard, so that statistics and setpoints can be exchanged back and forth. The device server speaks to the Model-T using [Protocol Buffers](https://en.wikipedia.org/wiki/Protocol_Buffers) and to the dashboard using JSON. The protobuf message formats are found in [brewbit/brewbit-protobuf-messages](https://github.com/brewbit/brewbit-protobuf-messages).
+
+* brewbit.com (this repo) provides the website at [http://brewbit.com/](http://brewbit.com/) including the web dashboard. It persists statistics in a PostgreSQL database and communicates to the Model-T devices via the brewbit-device-server. Most of the brewing dashboard code has been extracted to the gem [brewbit/brewbit-dashboard](https://github.com/brewbit/brewbit-dashboard).
+
+* A PostgreSQL database that holds statistics, device configurations, and even the firmware updates themselves.
+
+The device firmware can be found at [brewbit/model-t](https://github.com/brewbit/model-t).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_USER=brewbit
+      - POSTGRES_PASSWORD=brewbit
+#     volumes:
+#       - ./tmp/db:/var/lib/postgresql/data
+  web:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    environment:
+      - BREWBIT_DEVICE_GATEWAY_API_URL=http://dg:10080
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+  dg:
+    build: ../brewbit-device-server
+    command: bundle exec ./server.rb
+    environment:
+      - BREWBIT_API_HOST=web:3000
+    ports:
+      - "10080:10080"
+      - "31337:31337"
+    depends_on:
+      - web


### PR DESCRIPTION
This is the final piece of a project to add Docker support to BrewBit:

* brewbit/brewbit-device-server#1 - Add Dockerfile to the device server
* brewbit/brewbit-dashboard#7 - Make DEVICE_GATEWAY_API_URL configurable as an env
* brewbit/model-t#8 - Add Dockerized firmware build environment

I've marked this PR as WIP since it depends on the change to brewbit-dashboard. Once that one goes through, I can update the Gemfile and Gemfile.lock and remove the WIP tag.

I've been able to launch a local copy of the BrewBit services, activate my Model-T, receive statistics from the Model-T, and push a brewing config to the Model-T.

In theory a local server creates an alternate means to update the device firmware. However I don't currently know how to upload the firmware images to the Postgres database.